### PR TITLE
Add dotenv-based env loader, skip DB when MONGODB_URI unset, and add run guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# 실행 환경
+NODE_ENV=development
+
+# 서버 포트
+PORT=8080
+
+# MongoDB 연결 문자열
+# 예: mongodb://127.0.0.1:27017/carrot
+MONGODB_URI=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# 7weekDanggeunClone
+
+## 1) 베이직 환경설정
+```bash
+cp .env.example .env
+```
+
+`.env` 값 예시:
+```env
+NODE_ENV=development
+PORT=8080
+MONGODB_URI=mongodb://127.0.0.1:27017/carrot
+```
+
+> `MONGODB_URI`를 비워두면 DB 연결 없이 API 서버만 실행됩니다.
+
+## 2) 설치
+```bash
+npm install
+```
+
+## 3) 실행
+```bash
+npm start
+```
+
+## 4) 동작 확인
+```bash
+curl -sS http://127.0.0.1:8080/
+```
+정상 응답: `Backend Sever`
+
+---
+
+## npm SSL/프록시 이슈 빠른 복구 가이드
+프록시 없이 실행하려면 아래를 먼저 1회 실행하세요.
+
+```bash
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+unset npm_config_proxy npm_config_http_proxy npm_config_https_proxy
+npm config delete proxy
+npm config delete https-proxy
+npm config delete http-proxy
+npm config set registry https://registry.npmjs.org/
+npm config set strict-ssl true
+```
+
+그다음 설치/실행:
+```bash
+npm cache clean --force
+npm install
+npm start
+```

--- a/app.js
+++ b/app.js
@@ -6,14 +6,15 @@ const PostRouter = require("./router/postRouter");
 const likeRouter = require("./router/likeRouter");
 const connectDb = require("./database/database"); //몽고디비 스키마 연결
 const reqlogMiddleware = require("./middlewares/request-log-middleware");
+const env = require("./config/env");
 
-const port = 8080;
-
-connectDb(); //몽고디비 실행
+connectDb().catch((err) => {
+  console.error("MongoDB 연결 실패, 서버는 DB 없이 계속 실행됩니다.", err.message);
+}); //몽고디비 실행
 
 const corsOption = {
-    origin: "*",
-    credentials: true,
+  origin: "*",
+  credentials: true,
 };
 //cors 설정
 
@@ -24,7 +25,7 @@ const app = express();
 
 //body parser
 app.use(express.json());
-app.use(express.urlencoded({extended:false}));
+app.use(express.urlencoded({ extended: false }));
 
 //미들웨어 실행
 app.use(reqlogMiddleware);
@@ -32,14 +33,12 @@ app.use(cors(corsOption));
 
 //라우터 등록
 app.get("/", (req, res) => {
-    res.send("Backend Sever")
+  res.send("Backend Sever");
 });
 app.use("/api/user", UserRouter);
-
 app.use("/api/post", PostRouter);
-
 app.use("/api/like", likeRouter);
 
-app.listen(port, () => {
-    console.log(port, "포트로 서버가 켜졌어요~!")
+app.listen(env.port, () => {
+  console.log(`${env.port} 포트로 서버가 켜졌어요~! (${env.nodeEnv})`);
 });

--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,12 @@
+const path = require("path");
+const dotenv = require("dotenv");
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+const env = {
+  nodeEnv: process.env.NODE_ENV || "development",
+  port: Number(process.env.PORT || 8080),
+  mongodbUri: process.env.MONGODB_URI || "",
+};
+
+module.exports = env;

--- a/database/database.js
+++ b/database/database.js
@@ -1,15 +1,18 @@
 const mongoose = require("mongoose");
+const env = require("../config/env");
 
 function connectDb() {
-    return mongoose.connect(
-      "mongodb+srv://xoxokss:test@cluster0.dkb77.mongodb.net/carrot?retryWrites=true&w=majority",
-      // "mongodb+srv://test:sparta@cluster0.rx7dw.mongodb.net/minipjt?retryWrites=true&w=majority",
-      {
-       ignoreUndefined: true,
-       useNewUrlParser: true,
-       useUnifiedTopology: true,
-      }
-    )
-};
+  if (!env.mongodbUri) {
+    console.warn("MONGODB_URI가 설정되지 않아 DB 연결을 건너뜁니다.");
+    return Promise.resolve();
+  }
+
+  return mongoose.connect(env.mongodbUri, {
+    ignoreUndefined: true,
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
+
 module.exports = connectDb;
 //----------------------------------------------//

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
### Motivation
- Remove hardcoded runtime values (port and MongoDB URI) so the app can be configured per-environment and run locally without editing source files. 
- Make server startup resilient when MongoDB is not available by skipping DB connect if `MONGODB_URI` is not provided. 
- Provide a minimal onboarding guide and quick npm SSL/proxy recovery steps so developers can install and run the project reliably.

### Description
- Added `config/env.js` which loads `.env` using `dotenv` and exports `nodeEnv`, `port`, and `mongodbUri` for centralized environment access. 
- Updated `app.js` to use `env.port`/`env.nodeEnv` and to continue running even if `connectDb()` rejects (error is logged). 
- Rewrote `database/database.js` to read `MONGODB_URI` from the env loader and return a resolved promise (skip connect) when the value is empty. 
- Added `.env.example` with the minimal variables and `README.md` with setup/run steps and an npm SSL/proxy reset guide, and ensured a `start` script (`node app.js`) is present in `package.json`.

### Testing
- Automated start test: ran `npm start` in background and `curl -sS http://127.0.0.1:8080/` which returned `Backend Sever`, confirming HTTP server boots (succeeded). 
- Server logs test: inspected `/tmp/app.log` showing the message that `MONGODB_URI` is unset and the server started, confirming DB connect is skipped and process remains running (succeeded). 
- Package/script verification: ran `npm run` to confirm `start` script exists and `app.js` reads env values (succeeded). 
- Dependency installation: attempted `npm install` earlier and it failed with `ERR_SSL_CIPHER_OPERATION_FAILED` which is an environment/npm/OpenSSL issue and not caused by repository changes (failed due to local environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad29bc41c83208dd7ba31040807cf)